### PR TITLE
Only allow bookings for existing telescopes

### DIFF
--- a/src/models/telescope.rs
+++ b/src/models/telescope.rs
@@ -90,6 +90,11 @@ impl TelescopeCollectionHandle {
         telescopes_read_lock.get(id).cloned()
     }
 
+    pub async fn contains_key(&self, id: &str) -> bool {
+        let telescopes_read_lock = self.telescopes.read().await;
+        telescopes_read_lock.contains_key(id)
+    }
+
     pub fn get_names(&self) -> Vec<String> {
         self.names.clone()
     }

--- a/src/routes/booking.rs
+++ b/src/routes/booking.rs
@@ -88,6 +88,9 @@ async fn create_booking(
     let start_time: DateTime<Utc> = Utc.from_utc_datetime(&naive_datetime);
     let end_time = start_time + Duration::hours(booking_form.duration);
 
+    if !state.telescopes.contains_key(&booking_form.telescope).await {
+        return Ok(StatusCode::BAD_REQUEST.into_response());
+    }
     let booking = Booking {
         start_time,
         end_time,

--- a/templates/bookings.html
+++ b/templates/bookings.html
@@ -33,7 +33,7 @@
       <input type="text" id="duration" name="duration">
       <label for="telescope">Telescope</label>
       <select name="telescope" id="telescope">
-        <option value="">Any telescope</option>
+        <option value="">Select telescope</option>
         {% for name in telescope_names %}
         <option value="{{ name }}">{{ name }}</option>
         {% endfor %}


### PR DESCRIPTION
Through the frontend an empty telescope id could be provided or a request could come in with an unknonw id. Just reject the booking with code 400 if this happens.

Fixes #174.