### PR TITLE
Fix clippys

### DIFF
--- a/src/models/salsa_telescope.rs
+++ b/src/models/salsa_telescope.rs
@@ -278,7 +278,7 @@ fn median(mut xs: Vec<f64>) -> f64 {
     // sort in ascending order, panic on f64::NaN
     xs.sort_by(|x, y| x.partial_cmp(y).unwrap());
     let n = xs.len();
-    if n % 2 == 0 {
+    if n.is_multiple_of(2) {
         (xs[n / 2] + xs[n / 2 - 1]) / 2.0
     } else {
         xs[n / 2]

--- a/src/models/session.rs
+++ b/src/models/session.rs
@@ -112,10 +112,7 @@ impl Session {
         })
     }
 
-    pub async fn delete(
-        self: Self,
-        connection: Arc<Mutex<Connection>>,
-    ) -> Result<(), InternalError> {
+    pub async fn delete(self, connection: Arc<Mutex<Connection>>) -> Result<(), InternalError> {
         let conn = connection.lock().await;
 
         conn.execute("DELETE FROM session WHERE token = (?1)", (self.token,))

--- a/src/routes/telescope.rs
+++ b/src/routes/telescope.rs
@@ -45,31 +45,31 @@ async fn spectrum_handle_websocket(mut socket: WebSocket, telescope: TelescopeHa
     loop {
         let info = telescope.get_info().await;
         // Somehow signal the error ...
-        if let Ok(info) = info {
-            if let Some(observation) = info.latest_observation {
-                // Needed this temporary vector to convince Bytes::from that it
-                // could convert. The underlying buffer is maybe just moved?
-                //
-                // The data is interleaved (freq, spectrum) into one big array
-                // and then sent over the socket.
-                let byte_vec: Vec<u8> = observation
-                    .frequencies
-                    .iter()
-                    .zip(observation.spectra.iter())
-                    .flat_map(|(f, v)| {
-                        // Pack frequency and amplitude into 16-byte array.
-                        // This is one value sent over the socket.
-                        let mut res = [0; 16];
-                        res[..8].copy_from_slice(&f.to_le_bytes());
-                        res[8..].copy_from_slice(&v.to_le_bytes());
-                        res
-                    })
-                    .collect();
-                match socket.send(Message::Binary(Bytes::from(byte_vec))).await {
-                    Ok(_) => (),
-                    // No-one is listening anymore.
-                    Err(_) => return,
-                }
+        if let Ok(info) = info
+            && let Some(observation) = info.latest_observation
+        {
+            // Needed this temporary vector to convince Bytes::from that it
+            // could convert. The underlying buffer is maybe just moved?
+            //
+            // The data is interleaved (freq, spectrum) into one big array
+            // and then sent over the socket.
+            let byte_vec: Vec<u8> = observation
+                .frequencies
+                .iter()
+                .zip(observation.spectra.iter())
+                .flat_map(|(f, v)| {
+                    // Pack frequency and amplitude into 16-byte array.
+                    // This is one value sent over the socket.
+                    let mut res = [0; 16];
+                    res[..8].copy_from_slice(&f.to_le_bytes());
+                    res[8..].copy_from_slice(&v.to_le_bytes());
+                    res
+                })
+                .collect();
+            match socket.send(Message::Binary(Bytes::from(byte_vec))).await {
+                Ok(_) => (),
+                // No-one is listening anymore.
+                Err(_) => return,
             }
         }
         tokio::time::sleep(Duration::from_secs(1)).await;


### PR DESCRIPTION
We accept the lint to prefer `is_multple_of` over directly using modulus `%`. This _is_ clearer, and it never panics.